### PR TITLE
21 team count optional

### DIFF
--- a/src/Arena.cs
+++ b/src/Arena.cs
@@ -51,7 +51,7 @@ namespace Spite
         /// <param name="numberOfTeams">The number of teams fighting in the arena.</param>
         /// <param name="turnManager">The object that manages the turns in this arena.</param>
         /// <exception cref="ArgumentNullException">Thrown when turnManager is null.</exception>
-        public Arena(uint numberOfTeams, ITurnManager turnManager)
+        public Arena(int numberOfTeams, ITurnManager turnManager)
         {
             if (turnManager == null) {
                 throw new ArgumentNullException(nameof(turnManager));
@@ -66,7 +66,7 @@ namespace Spite
         /// <param name="name">The name of the arena.</param>
         /// <param name="numberOfTeams">The number of teams fighting in the arena.</param>
         /// <param name="turnManager">The object that manages the turns in this arena.</param>
-        public Arena(string name, uint numberOfTeams, ITurnManager turnManager) :
+        public Arena(string name, int numberOfTeams, ITurnManager turnManager) :
             this(numberOfTeams, turnManager)
         {
             ArenaName = name;

--- a/src/ArenaBuilder.cs
+++ b/src/ArenaBuilder.cs
@@ -13,7 +13,7 @@ namespace Spite
         /// <summary>
         /// The number of teams the arena should support.
         /// </summary>
-        private uint teamCount = 0;
+        private int teamCount = -1;
 
         /// <summary>
         /// The name of the arena.
@@ -52,7 +52,7 @@ namespace Spite
         /// </summary>
         /// <param name="teamCount">The number of teams that will be fighting in the arena.</param>
         /// <returns>this</returns>
-        public ArenaBuilder<T> SetTeamCount(uint teamCount)
+        public ArenaBuilder<T> SetTeamCount(int teamCount)
         {
             this.teamCount = teamCount;
             return this;
@@ -116,9 +116,9 @@ namespace Spite
         /// <returns>The arena builder for chaining.</returns>
         public ArenaBuilder<T> AddTeam(T team)
         {
-            if (teamsAdded >= teamCount)
+            if (teamCount > 0 && teamsAdded >= teamCount)
             {
-                throw new InvalidOperationException();
+                throw new InvalidOperationException($"This arena builder only supports {teamCount} teams");
             }
             teams.Add(team);
             ++teamsAdded;
@@ -173,13 +173,15 @@ namespace Spite
             {
                 throw new InvalidOperationException("A turn manager has not been set.");
             }
+            int totalTeams = teamCount > 0 ? teamCount : teamsAdded;
             var arena = arenaName == null ?
-                new Arena(teamCount, turnManager) :
-                new Arena(arenaName, teamCount, turnManager)
+                new Arena(totalTeams, turnManager) :
+                new Arena(arenaName, totalTeams, turnManager)
                 {
                     AllianceGraph = allianceGraph,
                 };
-
+            // Since Arena.teams is readonly we have to do it this way.
+            // Might want to look into another way
             for (int i = 0; i < teamsAdded; ++i)
             {
                 arena.teams[i] = teams[i];

--- a/tests/ArenaBuilderTests.cs
+++ b/tests/ArenaBuilderTests.cs
@@ -1,5 +1,6 @@
 ﻿using Spite.Turns;
 using NUnit.Framework;
+using System.Collections;
 
 namespace Spite.UnitTests
 {
@@ -14,13 +15,13 @@ namespace Spite.UnitTests
 		[SetUp]
 		public void SetUp()
 		{
-			MockTeamArenaBuilder = new ArenaBuilder<MockTeam>();
 			TeamA = new MockTeam();
 			TeamB = new MockTeam();
-			MockTeamArenaBuilder.SetTeamCount(2);
-			MockTeamArenaBuilder.AddTeam(TeamA);
-			MockTeamArenaBuilder.AddTeam(TeamB);
-			MockTeamArenaBuilder.SetTurnScheme(TurnSchemeType.DiscreteTeam);
+			MockTeamArenaBuilder = new ArenaBuilder<MockTeam>()
+				.SetTeamCount(2)
+				.AddTeam(TeamA)
+				.AddTeam(TeamB)
+				.SetTurnScheme(TurnSchemeType.DiscreteTeam);
 		}
 
 		[Test]
@@ -29,6 +30,24 @@ namespace Spite.UnitTests
 			// Uses the arena builder created in the setup method
 			Arena a = MockTeamArenaBuilder.Finish();
 			Assert.AreEqual(2, a.TeamCount);
+			var teamC = new MockTeam();
+			Assert.Throws<System.InvalidOperationException>(() =>
+			{
+				MockTeamArenaBuilder.AddTeam(teamC);
+			});
+
+			var unlimitedTeamArenaBuilder = new ArenaBuilder<MockTeam>()
+				.AddTeam(TeamA)
+				.AddTeam(TeamB)
+				.AddTeam(teamC)
+				.SetTurnScheme(TurnSchemeType.DiscreteTeam);
+
+			a = unlimitedTeamArenaBuilder.Finish();
+			Assert.AreEqual(3, a.TeamCount);
+			var teams = (ICollection)a.Teams;
+			Assert.Contains(TeamA, teams);
+			Assert.Contains(TeamB, teams);
+			Assert.Contains(teamC, teams);
 		}
 
 		[Test]


### PR DESCRIPTION
Closes #21.

Removes the requirement to set the amount of teams accepted by an arena builder.