### PR TITLE
58 iteam members as ilist

### DIFF
--- a/src/ITeam.cs
+++ b/src/ITeam.cs
@@ -48,7 +48,7 @@ namespace Spite
         /// <summary>
         /// The entities managed by this team.
         /// </summary>
-        ICollection<T> Members { get; }
+        IList<T> Members { get; }
 
         /// <summary>
         /// Adds an entity to the team.

--- a/tests/MockTeam.cs
+++ b/tests/MockTeam.cs
@@ -13,7 +13,7 @@ namespace Spite.UnitTests
         public TeamStanding CurrentStanding => TeamStanding.Inactive;
 
 		private readonly List<MockTappableTeammate> teammates = new List<MockTappableTeammate>();
-		public ICollection<MockTappableTeammate> Members => teammates;
+		public IList<MockTappableTeammate> Members => teammates;
 
 		public int ManagedEntityCount => teammates.Count;
 

--- a/tests/Mocks/MockPlayer.cs
+++ b/tests/Mocks/MockPlayer.cs
@@ -6,7 +6,7 @@ namespace Spite.UnitTests.Mocks
 	public class MockPlayer : ITeamExecutor<MockTeammate>
 	{
 		private readonly List<MockTeammate> teammates = new List<MockTeammate>();
-		public ICollection<MockTeammate> Members => teammates;
+		public IList<MockTeammate> Members => teammates;
 
 		public TeamStanding CurrentStanding {get; set;} = TeamStanding.Inactive;
 

--- a/tests/Mocks/Turns/AlwaysExecutableTurnPhase.cs
+++ b/tests/Mocks/Turns/AlwaysExecutableTurnPhase.cs
@@ -5,8 +5,6 @@ namespace Spite.UnitTests.Mocks.Turns
 {
     public class AlwaysExecutableTurnPhase : ITurnPhase
     {
-        public event ChangePhase OnPhaseChanged;
-
         public void GetNextPhase(ITurnManager manager)
         {
             throw new System.NotImplementedException();


### PR DESCRIPTION
This PR changes the ITeam<ITeammate>'s Member variable from ICollection to IList to provide easier access to the members without relying on Linq.